### PR TITLE
fix datascience handbook link

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -72,7 +72,7 @@
                   <p>One must learn how to code to be an effective cognitive neuroscience researcher. Our lab uses Python and Bash scripting for data analyses and statistics. Below are some recommended resources to get started on these languages. 
                   <li> <a href="https://learnpythonthehardway.org/book/"> Learn Python The Hard Way</a> is a great website for learning Python's syntax. <a href="https://www.codecademy.com/tracks/python"> Codecademy </a> is also great for beginners.</li>
                   <li> <a href="https://github.com/TomDonoghue/PythonBootcamp/blob/master/ProgrammingWithPython.ipynb">Here is a Jupyter notebook</a> with a great collection of scipy related links. </li>
-                  <li> Check out the <a href="https://learnpythonthehardway.org/book/"> Data Science Handbook by Jake Vanerplas </a> to learn Python packages for scientific computing (e.g., numpy, pandas, sci-kit learn). </li>
+                  <li> Check out the <a href="https://jakevdp.github.io/PythonDataScienceHandbook/"> Data Science Handbook by Jake Vanerplas </a> to learn Python packages for scientific computing (e.g., numpy, pandas, sci-kit learn). </li>
                   <li> Allmost all softwares developed for neuroimaging only run on Linux or MacOS, it is essential that you learn <a href="http://swcarpentry.github.io/shell-novice/">BASH command line</a> for scripting. Also check out this more advanced <a href="https://github.com/jlevy/the-art-of-command-line/blob/master/README.md"> tutorial. </a></li>
                   <li> Use <a href="http://seaborn.pydata.org/"> Seaborn </a> to make figures. </li>
                   <li> Learn <a href="https://regexr.com/"> Regular expression.</a></li>


### PR DESCRIPTION
Fixes #2 

Corrects the link for the python datascience handbook to the correct location. 